### PR TITLE
feat: support skit registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+scripts/.ibm-project

--- a/scripts/set_skit_env.sh
+++ b/scripts/set_skit_env.sh
@@ -22,6 +22,8 @@ echo "PAGERDUTY_EVENTS_API_URL=${PAGERDUTY_EVENTS_API_URL}" >> ./build.propertie
 echo "PAGERDUTY_API_TOKEN=${PAGERDUTY_API_TOKEN}" >> ./build.properties
 echo "PAGERDUTY_SVC_NAME=${PAGERDUTY_SVC_NAME}" >> ./build.properties
 echo "ENABLE_PD_ALERTS=${ENABLE_PD_ALERTS}" >> ./build.properties
+echo "SKIT_REG_ENDPOINT=${SKIT_REG_ENDPOINT}" >> ./build.properties
+echo "SKIT_REG_AUTH_TOKEN=${SKIT_REG_AUTH_TOKEN}" >> ./build.properties
 
 if [ "$DEPLOY_TARGET" == "cf" ]; then
     echo "ENABLED_CF=${ENABLED_CF}" >> ./build.properties

--- a/scripts/skit_registration.sh
+++ b/scripts/skit_registration.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # uncomment to debug the script wherever it is used
-set -x
+# set -x
 
 function register_skit {
     OUT_FILE_RUN=run-pipeline-output.txt

--- a/scripts/skit_registration.sh
+++ b/scripts/skit_registration.sh
@@ -2,74 +2,77 @@
 # uncomment to debug the script wherever it is used
 # set -x
 
-OUT_FILE_RUN=run-pipeline-output.txt
+function register_skit {
+    OUT_FILE_RUN=run-pipeline-output.txt
 
-echo "Triggering starter kit registration..."
-curl -s -X POST \
-  ${SKIT_REG_ENDPOINT} \
-  -H 'cache-control: no-cache' \
-  -H 'content-type: application/json' \
-  -H 'x-auth-token: '${SKIT_REG_AUTH_TOKEN}'' \
-  -d '{
-  "ref": "refs/heads/'${GIT_BRANCH}'",
-  "after": "'${GIT_COMMIT}'",
-  "repository": {
-    "name": "'${APP_NAME}'",
-    "full_name": "IBM/'${APP_NAME}'",
-    "url": "https://github.com/IBM/'${APP_NAME}'",
-    "html_url": "https://github.com/IBM/'${APP_NAME}'",
-    "statuses_url": "https://api.github.com/repos/IBM/'${APP_NAME}'/statuses/{sha}"
-  },
-  "skit_verified": "true"
-}' >> $OUT_FILE_RUN
+    echo "Triggering starter kit registration..."
+    curl -s -X POST \
+    ${SKIT_REG_ENDPOINT} \
+    -H 'cache-control: no-cache' \
+    -H 'content-type: application/json' \
+    -H 'x-auth-token: '${SKIT_REG_AUTH_TOKEN}'' \
+    -d '{
+    "ref": "refs/heads/'${GIT_BRANCH}'",
+    "after": "'${GIT_COMMIT}'",
+    "repository": {
+        "name": "'${APP_NAME}'",
+        "full_name": "IBM/'${APP_NAME}'",
+        "url": "https://github.com/IBM/'${APP_NAME}'",
+        "html_url": "https://github.com/IBM/'${APP_NAME}'",
+        "statuses_url": "https://api.github.com/repos/IBM/'${APP_NAME}'/statuses/{sha}"
+    },
+    "skit_verified": "true"
+    }' >> $OUT_FILE_RUN
 
-echo ""
-echo "Registration pipeline response:"
-cat $OUT_FILE_RUN
-echo ""
-echo ""
+    echo ""
+    echo "Registration pipeline response:"
+    cat $OUT_FILE_RUN
+    echo ""
+    echo ""
 
-PIPELINE_INFO_URL=$(cat $OUT_FILE_RUN | jq '.url')
-TEMP="${PIPELINE_INFO_URL%\"}"
-TEMP="${TEMP#\"}"
-PIPELINE_INFO_URL=${TEMP}
-echo "Pipeline info URL: $PIPELINE_INFO_URL"
-
-IAM_TOKEN=$(ibmcloud iam oauth-tokens --output json | jq '.iam_token')
-TEMP="${IAM_TOKEN%\"}"
-TEMP="${TEMP#\"}"
-IAM_TOKEN=${TEMP}
-
-echo ""
-echo "Checking pipeline run status..."
-SUCCESS="false"
-for ITERATION in {1..30}
-do
-    sleep 10
-
-    STATUS=$(curl -s -X GET -H "Authorization: $IAM_TOKEN" $PIPELINE_INFO_URL | jq '.status.state')
-    TEMP="${STATUS%\"}"
+    PIPELINE_INFO_URL=$(cat $OUT_FILE_RUN | jq '.url')
+    TEMP="${PIPELINE_INFO_URL%\"}"
     TEMP="${TEMP#\"}"
-    STATUS=${TEMP}
-    echo "Pipeline run status: $STATUS"
+    PIPELINE_INFO_URL=${TEMP}
+    echo "Pipeline info URL: $PIPELINE_INFO_URL"
 
-    if [ "$STATUS" == "failed" ]; then
-        echo "Pipeline run failed!"
-        break
-    elif [ "$STATUS" == "succeeded" ]; then
-        echo "Pipeline run is finished!"
-        SUCCESS="true"
-        break
+    IAM_TOKEN=$(ibmcloud iam oauth-tokens --output json | jq '.iam_token')
+    TEMP="${IAM_TOKEN%\"}"
+    TEMP="${TEMP#\"}"
+    IAM_TOKEN=${TEMP}
+
+    echo ""
+    echo "Checking pipeline run status..."
+    SUCCESS="false"
+    for ITERATION in {1..30}
+    do
+        sleep 10
+
+        STATUS=$(curl -s -X GET -H "Authorization: $IAM_TOKEN" $PIPELINE_INFO_URL | jq '.status.state')
+        TEMP="${STATUS%\"}"
+        TEMP="${TEMP#\"}"
+        STATUS=${TEMP}
+        echo "Pipeline run status: $STATUS"
+
+        if [ "$STATUS" == "failed" ]; then
+            echo "Pipeline run failed!"
+            break
+        elif [ "$STATUS" == "succeeded" ]; then
+            echo "Pipeline run is finished!"
+            SUCCESS="true"
+            break
+        else
+            echo "Pipeline run is not finished, retrying after waiting..."
+        fi
+    done
+
+    rm $OUT_FILE_RUN
+
+    if [ "$SUCCESS" == "false" ]; then
+        echo "Registration failed. Check the registration pipeline logs for details."
+        return 1
     else
-        echo "Pipeline run is not finished, retrying after waiting..."
+        echo "Skit registration succeeded!"
+        return 0
     fi
-done
-
-rm $OUT_FILE_RUN
-
-if [ "$SUCCESS" == "false" ]; then
-    echo "Registration failed. Check the registration pipeline logs for details."
-    exit 1
-else
-    echo "Skit registration succeeded!"
-fi
+}

--- a/scripts/skit_registration.sh
+++ b/scripts/skit_registration.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # uncomment to debug the script wherever it is used
-# set -x
+set -x
 
 function register_skit {
     OUT_FILE_RUN=run-pipeline-output.txt

--- a/scripts/skit_registration.sh
+++ b/scripts/skit_registration.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# uncomment to debug the script wherever it is used
+# set -x
+
+echo "Registering starter kit..."
+curl -X POST \
+  ${SKIT_REG_ENDPOINT} \
+  -H 'cache-control: no-cache' \
+  -H 'content-type: application/json' \
+  -H 'x-auth-token: '${SKIT_REG_AUTH_TOKEN}'' \
+  -d '{
+  "ref": "refs/heads/'${GIT_BRANCH}'",
+  "after": "'${GIT_COMMIT}'",
+  "repository": {
+    "name": "'${APP_NAME}'",
+    "full_name": "IBM/'${APP_NAME}'",
+    "url": "https://github.com/IBM/'${APP_NAME}'",
+    "html_url": "https://github.com/IBM/'${APP_NAME}'",
+    "statuses_url": "https://api.github.com/repos/IBM/'${APP_NAME}'/statuses/{sha}"
+  }
+}'

--- a/scripts/skit_registration.sh
+++ b/scripts/skit_registration.sh
@@ -53,12 +53,15 @@ do
     STATUS=${TEMP}
     echo "Pipeline run status: $STATUS"
 
-    if [ "$STATUS" != "succeeded" ]; then
-        echo "Pipeline run is not finished, retrying after waiting..."
-    else
+    if [ "$STATUS" == "failed" ]; then
+        echo "Pipeline run failed!"
+        break
+    elif [ "$STATUS" == "succeeded" ]
         echo "Pipeline run is finished!"
         SUCCESS="true"
         break
+    else
+        echo "Pipeline run is not finished, retrying after waiting..."
     fi
 done
 

--- a/scripts/skit_registration.sh
+++ b/scripts/skit_registration.sh
@@ -2,8 +2,10 @@
 # uncomment to debug the script wherever it is used
 # set -x
 
-echo "Registering starter kit..."
-curl -X POST \
+OUT_FILE_RUN=run-pipeline-output.txt
+
+echo "Triggering starter kit registration..."
+curl -s -X POST \
   ${SKIT_REG_ENDPOINT} \
   -H 'cache-control: no-cache' \
   -H 'content-type: application/json' \
@@ -17,5 +19,54 @@ curl -X POST \
     "url": "https://github.com/IBM/'${APP_NAME}'",
     "html_url": "https://github.com/IBM/'${APP_NAME}'",
     "statuses_url": "https://api.github.com/repos/IBM/'${APP_NAME}'/statuses/{sha}"
-  }
-}'
+  },
+  "skit_verified": "true"
+}' >> $OUT_FILE_RUN
+
+echo ""
+echo "Registration pipeline response:"
+cat $OUT_FILE_RUN
+echo ""
+echo ""
+
+PIPELINE_INFO_URL=$(cat $OUT_FILE_RUN | jq '.url')
+TEMP="${PIPELINE_INFO_URL%\"}"
+TEMP="${TEMP#\"}"
+PIPELINE_INFO_URL=${TEMP}
+echo "Pipeline info URL: $PIPELINE_INFO_URL"
+
+IAM_TOKEN=$(ibmcloud iam oauth-tokens --output json | jq '.iam_token')
+TEMP="${IAM_TOKEN%\"}"
+TEMP="${TEMP#\"}"
+IAM_TOKEN=${TEMP}
+
+echo ""
+echo "Checking pipeline run status..."
+SUCCESS="false"
+for ITERATION in {1..30}
+do
+    sleep 10
+
+    STATUS=$(curl -s -X GET -H "Authorization: $IAM_TOKEN" $PIPELINE_INFO_URL | jq '.status.state')
+    TEMP="${STATUS%\"}"
+    TEMP="${TEMP#\"}"
+    STATUS=${TEMP}
+    echo "Pipeline run status: $STATUS"
+
+    if [ "$STATUS" != "succeeded" ]; then
+        echo "Pipeline run is not finished, retrying after waiting..."
+    else
+        echo "Pipeline run is finished!"
+        SUCCESS="true"
+        break
+    fi
+done
+
+rm $OUT_FILE_RUN
+
+if [ "$SUCCESS" == "false" ]; then
+    echo "Registration failed. Check the registration pipeline logs for details."
+    exit 1
+else
+    echo "Skit registration succeeded!"
+fi

--- a/scripts/skit_registration.sh
+++ b/scripts/skit_registration.sh
@@ -70,9 +70,9 @@ function register_skit {
 
     if [ "$SUCCESS" == "false" ]; then
         echo "Registration failed. Check the registration pipeline logs for details."
-        return 1
+        export REG_EXIT=1
     else
         echo "Skit registration succeeded!"
-        return 0
+        export REG_EXIT=0
     fi
 }

--- a/scripts/skit_registration.sh
+++ b/scripts/skit_registration.sh
@@ -56,7 +56,7 @@ do
     if [ "$STATUS" == "failed" ]; then
         echo "Pipeline run failed!"
         break
-    elif [ "$STATUS" == "succeeded" ]
+    elif [ "$STATUS" == "succeeded" ]; then
         echo "Pipeline run is finished!"
         SUCCESS="true"
         break

--- a/scripts/slack_message.sh
+++ b/scripts/slack_message.sh
@@ -12,14 +12,14 @@ if [[ -n $APP_URL ]]; then
 fi
 
 if [ "${NOTIFY}" == "true" ]; then
-    curl -v POST --data-urlencode 'payload={"channel": "#'"$OWNER_SLACK_CHANNEL"'", 
+    curl POST --data-urlencode 'payload={"channel": "#'"$OWNER_SLACK_CHANNEL"'", 
                                     "username": "DevX Skit Monitor", 
                                     "text": "'"$TEXT"' @here", 
                                     "link_names": "true",
                                     "attachments": [], "icon_emoji": ":police_car:"}' \
     $SLACK_WEBHOOK
 else
-    curl -v POST --data-urlencode 'payload={"channel": "#'"$OWNER_SLACK_CHANNEL"'", 
+    curl POST --data-urlencode 'payload={"channel": "#'"$OWNER_SLACK_CHANNEL"'", 
                                     "username": "DevX Skit Monitor", 
                                     "text": "'"$TEXT"'", 
                                     "attachments": [], "icon_emoji": ":police_car:"}' \

--- a/scripts/slack_message.sh
+++ b/scripts/slack_message.sh
@@ -12,14 +12,14 @@ if [[ -n $APP_URL ]]; then
 fi
 
 if [ "${NOTIFY}" == "true" ]; then
-    curl POST --data-urlencode 'payload={"channel": "#'"$OWNER_SLACK_CHANNEL"'", 
+    curl -s -X POST --data-urlencode 'payload={"channel": "#'"$OWNER_SLACK_CHANNEL"'", 
                                     "username": "DevX Skit Monitor", 
                                     "text": "'"$TEXT"' @here", 
                                     "link_names": "true",
                                     "attachments": [], "icon_emoji": ":police_car:"}' \
     $SLACK_WEBHOOK
 else
-    curl POST --data-urlencode 'payload={"channel": "#'"$OWNER_SLACK_CHANNEL"'", 
+    curl -s -X POST --data-urlencode 'payload={"channel": "#'"$OWNER_SLACK_CHANNEL"'", 
                                     "username": "DevX Skit Monitor", 
                                     "text": "'"$TEXT"'", 
                                     "attachments": [], "icon_emoji": ":police_car:"}' \

--- a/scripts/verification_experience_test.sh
+++ b/scripts/verification_experience_test.sh
@@ -51,7 +51,10 @@ else
   exit 1
 fi
 
+set -e
+EXIT_CODE=0
 if [ "$PASSED" == "true" ]; then
+  echo "Beginning skit registration..."
   source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/skit_registration.sh") || EXIT_CODE=$?
   if [ $EXIT_CODE != 0 ]; then
     msg="Skit registration failed. Check the Tekton registration pipeline logs for details."

--- a/scripts/verification_experience_test.sh
+++ b/scripts/verification_experience_test.sh
@@ -32,6 +32,7 @@ if [ -f "$exp_test_path" ]; then
     pass_msg="Skit Experience Test Passed :white_check_mark:"
     echo $pass_msg
     source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/slack_message.sh") "$pass_msg" "false"
+    source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/skit_registration.sh")
     exit 0
   else
     fail_msg="Skit Experience Test Failed"

--- a/scripts/verification_experience_test.sh
+++ b/scripts/verification_experience_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # uncomment to debug the script wherever it is used
-# set -x
+set -x
 
 exp_test_script=experience_test.sh
 exp_test_path=./scripts/$exp_test_script

--- a/scripts/verification_experience_test.sh
+++ b/scripts/verification_experience_test.sh
@@ -25,15 +25,15 @@ echo "The APP_URL is: $APP_URL"
 set -e
 EXIT_CODE=0
 
+PASSED="false"
 if [ -f "$exp_test_path" ]; then
   cd ./scripts
   source "./$exp_test_script" || EXIT_CODE=$?
   if [ $EXIT_CODE == 0 ]; then
+    PASSED="true"
     pass_msg="Skit Experience Test Passed :white_check_mark:"
     echo $pass_msg
     source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/slack_message.sh") "$pass_msg" "false"
-    source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/skit_registration.sh")
-    exit 0
   else
     fail_msg="Skit Experience Test Failed"
     echo $fail_msg
@@ -49,4 +49,14 @@ else
   msg="$msg :spinning-siren:"
   source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/slack_message.sh") "$msg"
   exit 1
+fi
+
+if [ "$PASSED" == "true" ]; then
+  source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/skit_registration.sh") || EXIT_CODE=$?
+  if [ $EXIT_CODE != 0 ]; then
+    msg="Skit registration failed. Check the Tekton registration pipeline logs for details."
+    fail_msg="$msg :spinning-siren:"
+    source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/slack_message.sh") "$fail_msg"
+    exit 1
+  fi
 fi

--- a/scripts/verification_experience_test.sh
+++ b/scripts/verification_experience_test.sh
@@ -55,7 +55,8 @@ set -e
 EXIT_CODE=0
 if [ "$PASSED" == "true" ]; then
   echo "Beginning skit registration..."
-  source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/skit_registration.sh") || EXIT_CODE=$?
+  source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/skit_registration.sh")
+  EXIT_CODE=$(register_skit)
   if [ $EXIT_CODE != 0 ]; then
     msg="Skit registration failed. Check the Tekton registration pipeline logs for details."
     fail_msg="$msg :spinning-siren:"

--- a/scripts/verification_experience_test.sh
+++ b/scripts/verification_experience_test.sh
@@ -56,8 +56,8 @@ EXIT_CODE=0
 if [ "$PASSED" == "true" ]; then
   source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/skit_registration.sh")
   echo "Beginning skit registration..."
-  EXIT_CODE=$(register_skit)
-  if [ $EXIT_CODE != 0 ]; then
+  register_skit
+  if [ $REG_EXIT != 0 ]; then
     msg="Skit registration failed. Check the Tekton registration pipeline logs for details."
     fail_msg="$msg :spinning-siren:"
     source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/slack_message.sh") "$fail_msg"

--- a/scripts/verification_experience_test.sh
+++ b/scripts/verification_experience_test.sh
@@ -54,8 +54,8 @@ fi
 set -e
 EXIT_CODE=0
 if [ "$PASSED" == "true" ]; then
-  echo "Beginning skit registration..."
   source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/skit_registration.sh")
+  echo "Beginning skit registration..."
   EXIT_CODE=$(register_skit)
   if [ $EXIT_CODE != 0 ]; then
     msg="Skit registration failed. Check the Tekton registration pipeline logs for details."

--- a/scripts/verification_experience_test.sh
+++ b/scripts/verification_experience_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # uncomment to debug the script wherever it is used
-set -x
+# set -x
 
 exp_test_script=experience_test.sh
 exp_test_path=./scripts/$exp_test_script
@@ -58,7 +58,7 @@ if [ "$PASSED" == "true" ]; then
   echo "Beginning skit registration..."
   register_skit
   if [ $REG_EXIT != 0 ]; then
-    msg="Skit registration failed. Check the Tekton registration pipeline logs for details."
+    msg="Skit registration failed. Check the starter-kit-registration Tekton pipeline logs under DevOps Toolchains for details."
     fail_msg="$msg :spinning-siren:"
     source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/slack_message.sh") "$fail_msg"
     exit 1


### PR DESCRIPTION
Skit registration is triggered using the new [Tekton Pipeline](https://cloud.ibm.com/devops/pipelines/tekton/111efe7d-5858-4d5b-a5b4-cdd1d591ff78?env_id=ibm:yp:us-south). The `skit_verified` property will be used in the registration code to determine if the registration trigger came from the monitoring toolchains (for master) or not (for other branches).

Associated monitoring toolchain template changes: https://github.com/IBM/devex-skit-monitor-toolchain/pull/10/files