### PR TITLE
fix: the APP_URL should be secured

### DIFF
--- a/scripts/deploy_cf.sh
+++ b/scripts/deploy_cf.sh
@@ -25,7 +25,7 @@ else
 fi
 # Export app name and URL for use in later Pipeline jobs
 export CF_APP_NAME="$CF_APP"
-export APP_URL=http://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
+export APP_URL=https://$(cf app $CF_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
 echo "APP_URL=${APP_URL}" >> $ARCHIVE_DIR/build.properties
 
 # copy build props to root dir build props


### PR DESCRIPTION
The `http://` is breaking CF deploys for the Nodejs+Cloudant app. Plus, the UI uses an `https://` preface anyway. 