### PR TITLE
fix: reset EXIT_CODE

### DIFF
--- a/scripts/verification_experience_test.sh
+++ b/scripts/verification_experience_test.sh
@@ -44,6 +44,7 @@ if [ -f "$exp_test_path" ]; then
     else
       echo "Skit Experience Test attempt $i failed"
       PASSED="false"
+      EXIT_CODE=0
     fi
   done
 else


### PR DESCRIPTION
If a test fails on the first attempt, the logic never resets the `EXIT_CODE` variable back to `0`, so the `if` statement will continue to think the experience test failed for the remaining two attempts.  
```
Running UI test using Selenium...
The last entry in the 'responseArea' element is: 20201114152642143806
Experience Test Successful
Skit Experience Test attempt 2 failed
Beginning Skit Experience Test attempt 3
```