### PR TITLE
fix: Refactor alert (#80)

### DIFF
--- a/scripts/verification_experience_test.sh
+++ b/scripts/verification_experience_test.sh
@@ -34,9 +34,6 @@ if [ -f "$exp_test_path" ]; then
       PASSED="true"
       pass_msg=":white_check_mark: Skit Experience Test Passed"
       echo $pass_msg
-      if [ $ENABLE_SLACK_ALERTS == "true" ]; then
-        source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/slack_message.sh") "$pass_msg" "false"
-      fi
       break
     else
       echo "Skit Experience Test attempt $i failed"
@@ -47,13 +44,6 @@ if [ -f "$exp_test_path" ]; then
 else
   msg="Skit Experience Test script not found for skit $APP_NAME."
   echo $msg
-  if [ "$ENABLE_PD_ALERTS" == "true" ]; then
-    source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/pagerduty_alert.sh") "$msg" "$pd_evt_action" "$pd_class" "$pd_svc_name" "$pd_severity"
-  fi
-  msg=":spinning-siren: $msg "
-  if [ $ENABLE_SLACK_ALERTS == "true" ]; then
-    source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/slack_message.sh") "$msg"
-  fi
   exit 1
 fi
 
@@ -61,31 +51,7 @@ set -e
 EXIT_CODE=0
 
 if [ "$PASSED" == "false" ]; then
-  fail_msg="Skit Experience Test Failed"
+  fail_msg="Skit Experience Test Failed after multiple attempts"
   echo $fail_msg
-  
-  if [ "$ENABLE_PD_ALERTS" == "true" ]; then
-    source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/pagerduty_alert.sh") "$fail_msg" "$pd_evt_action" "$pd_class" "$pd_svc_name" "$pd_severity"
-  fi
-  
-  fail_msg=":spinning-siren: $fail_msg "
-
-  if [ $ENABLE_SLACK_ALERTS == "true" ]; then
-    source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/slack_message.sh") "$fail_msg"
-  fi
   exit 1
-fi
-
-if [ "$PASSED" == "true" ] && [ "$DEPLOY_TARGET" != "cf" ] && [ "$REGISTER_SKIT" == "true" ]; then
-  source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/skit_registration.sh")
-  echo "Beginning skit registration..."
-  register_skit
-  if [ $REG_EXIT != 0 ]; then
-    msg="Skit registration failed. Check the starter-kit-registration Tekton pipeline logs under DevOps Toolchains for details."
-    fail_msg=":spinning-siren: $msg"
-    if [ $ENABLE_SLACK_ALERTS == "true" ]; then
-      source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/slack_message.sh") "$fail_msg"
-    fi
-    exit 1
-  fi
 fi


### PR DESCRIPTION
* chore: readme updates

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* feat: updated slack msg format

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: inline url fix

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* feat: add script versioning (#14)

* feat: scripts versioning

* fix: pass down assets git branch and version

* fix: add versioning to script contents

* fix: account for empty APP_URL

* chore: minor comment edits

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: revert v1 versioning to use GH releases (#16)

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: use GH release versioning

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: use release version instead of branch (#17)

* fix: revert v1 versioning to use GH releases

* fix: use release version instead of branch

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* feat: support skit registration (#19)

* feat: support skit registration

* feat: support skit reg tekton pipeline

* fix: add skit reg build props

* fix: check for pipeline failure and report reg failure

* fix: script elif fix

* fix: remove curl debugging

* fix: fail if reg fails

* fix: convert skit reg to function

* chore: debug skit reg function

* chore: debugging

* fix: use export var

* chore: disable debugging and message tweak

* fix: silence curl for slack msgs

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: skit reg name (#21)

* fix: typo

* fix: skit name

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: disable skit reg on CF for now

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: update to CLI ks commands

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* feat: support watson skits (#27)

* feat: support watson skits

* feat: more deploy assets

* feat: support sending to second slack channel

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: switch to webhooks only for slack msgs (#29)

* fix: switch to webhooks only for slack msgs

* chore: disable debugging

* fix: message format tweaks

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: watson deploy asset fixes and more time registering

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* feat: support long skit names in helm deploy (#32)

* feat: support long skit names in helm deploy

* fix: add short name for watson vis rec

* fix: add short names for all watson skits

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: use appman link for starters (#35)

* fix: use appman link for starters

* fix: use appman URL for starters

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* Merge development to master (#37)

* fix: use appman link for starters

* fix: use appman URL for starters

* fix: install missing python deps (#36)

* fix: install missing python deps

* fix: switch to apt-get

* fix: dont install pip via apt-get

* fix: proper pip install

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* feat: add retry logic for experience test (#38)

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* update openliberty path and env

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: the APP_URL should be secured

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: secured APP_URL

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: reset EXIT_CODE

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* chore: remove knative

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* change to Helm 3

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* Remove assets for unsupported/deprecated flows

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* Pass app URL from deploy to experience test

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* Switch sdk-for-nodejs to nodejs_buildpack

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix(install_chrome.sh): fix chrome driver version to 89

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* feat: tekton migration

fix scripts path

fix slack message

fix pipeline run logs url

remove unsupported slack msg portion

add copy assets script

fix dest dir

dont set env vars here

disable mention for now

only set app url if necessary

msg tweaks

fix: skit url

fix pipeline run url

fix alert logs URL

fix skit url during reg

fix skit url

fix python chart names

use separate var

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: update to latest chrome driver

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* Skit monitoring pr pipeline support (#64)

* the skit name is the skit name

* use cf-app directly

* added new helm files

* Added all helm pr config files

* refactor skit-verification; add alert conditionals

* add registration flag

* Use SKIT_NAME from env not creating

* Fixed missing quote

* Removed unused added script

Co-authored-by: nfstein <nicksteinhauser@gmail.com>
Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix(install_chrome): update chromedriver

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* bump chrome version

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* bump chromedriver version

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* update chromedriver to 99

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* dynamic chrome driver versioning

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix driver version

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* add vapor deployment assets

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* chore: rm cf deploy assets

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* chore: add cf back for java

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix: refactor alert into separate tasks

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

* fix message

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>

Signed-off-by: Gabriel Valencia <gvalenc@us.ibm.com>
Co-authored-by: Chuck Cox <chuckc@us.ibm.com>
Co-authored-by: Youming Lin <youming-lin@users.noreply.github.com>
Co-authored-by: Youming Lin <ylin@Youmings-MacBook-Pro.local>
Co-authored-by: Joseph Meis <jmeis@users.noreply.github.com>
Co-authored-by: Trevor Bolton <52944725+TBolton2000@users.noreply.github.com>
Co-authored-by: nfstein <nicksteinhauser@gmail.com>